### PR TITLE
Added missing nginx config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,44 @@
+server {
+    listen       80;
+    server_name  localhost;
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri /index.html;                 
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
Hi Max, after looking closer at the page : 
https://medium.com/greedygame-engineering/so-you-want-to-dockerize-your-react-app-64fbbb74c217

Toward the bottom it mentions that we needed to add this NGINX configuration file.

Now I was able to execute the two lines from a cmd prompt 
docker build . -t react-docker
docker run -p 8000:80 -it react-docker

and then go to http://localhost:8000 to access the dockerized version.  Hope you get a chance to try this yourself.
